### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The House of Mirth</i><br/>
-			was published in 1903 by<br/>
+			was published in 1905 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Edith_Wharton">Edith Wharton</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>


### PR DESCRIPTION
Changed the date of publication from 1903 to 1905.

Multiple sources (linked below) cite the publication date as 1905. The story even began serialization in 1905 in the Scribner's Magazine.

Internet Archives:
https://archive.org/details/wharton_edith_1862_1937_house_of_mirth https://archive.org/details/houseofmirth0000whar_x9w7

British Library:
https://bll01.primo.exlibrisgroup.com/discovery/fulldisplay?docid=alma990039009050100000&context=L&vid=44BL_INST:BLL01&lang=en&search_scope=Not_BL_Suppress&adaptor=Local%20Search%20Engine&tab=LibraryCatalog&query=any,contains,the%20house%20of%20mirth&sortby=title&facet=frbrgroupid,include,9026509540829403649&offset=0